### PR TITLE
example/randr: check the GetOutputInfo's mode length (virtual head can h...

### DIFF
--- a/examples/randr/main.go
+++ b/examples/randr/main.go
@@ -45,7 +45,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		if len(info.Modes) > 0 {
+		if info.Connection == randr.ConnectionConnected {
 			bestMode := info.Modes[0]
 			for _, mode := range resources.Modes {
 				if mode.Id == uint32(bestMode) {


### PR DESCRIPTION
...ave zero mode)

My PC's xrand output

```
snyh:randr$xrandr 
Screen 0: minimum 320 x 200, current 1440 x 900, maximum 32767 x 32767
VGA1 connected primary 1440x900+0+0 (normal left inverted right x axis y axis) 408mm x 255mm
   1440x900       59.9*+   75.0  
   1280x1024      75.0     60.0  
   1280x960       60.0  
   1280x800       59.8  
   1152x864       75.0  
   1024x768       75.1     70.1     60.0  
   832x624        74.6  
   800x600        72.2     75.0     60.3     56.2  
   640x480        75.0     72.8     66.7     60.0  
   720x400        70.1  
VIRTUAL1 disconnected (normal left inverted right x axis y axis)
```

the virtual1 will cause panic
