### PR TITLE
Fix Issue #21: automatic calculation of alignment padding after lists

### DIFF
--- a/dri2/dri2.go
+++ b/dri2/dri2.go
@@ -76,7 +76,7 @@ func (v AttachFormat) Bytes() []byte {
 	xgb.Put32(buf[b:], v.Format)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // AttachFormatListBytes writes a list of AttachFormat values to a byte slice.
@@ -281,7 +281,7 @@ func (v DRI2Buffer) Bytes() []byte {
 	xgb.Put32(buf[b:], v.Flags)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // DRI2BufferListBytes writes a list of DRI2Buffer values to a byte slice.
@@ -567,7 +567,7 @@ func connectReply(buf []byte) *ConnectReply {
 
 	v.AlignmentPad = make([]byte, (((int(v.DriverNameLength) + 3) & -4) - int(v.DriverNameLength)))
 	copy(v.AlignmentPad[:(((int(v.DriverNameLength)+3)&-4)-int(v.DriverNameLength))], buf[b:])
-	b += xgb.Pad(int((((int(v.DriverNameLength) + 3) & -4) - int(v.DriverNameLength))))
+	b += int((((int(v.DriverNameLength) + 3) & -4) - int(v.DriverNameLength)))
 
 	{
 		byteString := make([]byte, v.DeviceNameLength)
@@ -914,7 +914,6 @@ func getBuffersRequest(c *xgb.Conn, Drawable xproto.Drawable, Count uint32, Atta
 		xgb.Put32(buf[b:], Attachments[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }

--- a/examples/randr/main.go
+++ b/examples/randr/main.go
@@ -63,7 +63,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("X: %d, Y: %d, Width: %d, Height: %d\n",
+		fmt.Printf("%v, X: %d, Y: %d, Width: %d, Height: %d\n",
 			info.X, info.Y, info.Width, info.Height)
 	}
 

--- a/glx/glx.go
+++ b/glx/glx.go
@@ -1097,7 +1097,6 @@ func areTexturesResidentReply(buf []byte) *AreTexturesResidentReply {
 		}
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -1128,7 +1127,6 @@ func areTexturesResidentRequest(c *xgb.Conn, ContextTag ContextTag, N int32, Tex
 		xgb.Put32(buf[b:], Textures[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1192,7 +1190,6 @@ func changeDrawableAttributesRequest(c *xgb.Conn, Drawable Drawable, NumAttribs 
 		xgb.Put32(buf[b:], Attribs[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1256,7 +1253,7 @@ func clientInfoRequest(c *xgb.Conn, MajorVersion uint32, MinorVersion uint32, St
 	b += 4
 
 	copy(buf[b:], String[:StrLen])
-	b += xgb.Pad(int(StrLen))
+	b += int(StrLen)
 
 	return buf
 }
@@ -1475,7 +1472,6 @@ func createContextAttribsARBRequest(c *xgb.Conn, Context Context, Fbconfig Fbcon
 		xgb.Put32(buf[b:], Attribs[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1685,7 +1681,6 @@ func createPbufferRequest(c *xgb.Conn, Screen uint32, Fbconfig Fbconfig, Pbuffer
 		xgb.Put32(buf[b:], Attribs[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1758,7 +1753,6 @@ func createPixmapRequest(c *xgb.Conn, Screen uint32, Fbconfig Fbconfig, Pixmap x
 		xgb.Put32(buf[b:], Attribs[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1831,7 +1825,6 @@ func createWindowRequest(c *xgb.Conn, Screen uint32, Fbconfig Fbconfig, Window x
 		xgb.Put32(buf[b:], Attribs[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1956,7 +1949,6 @@ func deleteQueriesARBRequest(c *xgb.Conn, ContextTag ContextTag, N int32, Ids []
 		xgb.Put32(buf[b:], Ids[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -2020,7 +2012,6 @@ func deleteTexturesRequest(c *xgb.Conn, ContextTag ContextTag, N int32, Textures
 		xgb.Put32(buf[b:], Textures[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -2714,7 +2705,6 @@ func genQueriesARBReply(buf []byte) *GenQueriesARBReply {
 		v.Data[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -2812,7 +2802,6 @@ func genTexturesReply(buf []byte) *GenTexturesReply {
 		v.Data[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -2929,7 +2918,6 @@ func getBooleanvReply(buf []byte) *GetBooleanvReply {
 		}
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -3027,7 +3015,6 @@ func getClipPlaneReply(buf []byte) *GetClipPlaneReply {
 		v.Data[i] = Float64(xgb.Get64(buf[b:]))
 		b += 8
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -3129,7 +3116,7 @@ func getColorTableReply(buf []byte) *GetColorTableReply {
 
 	v.Data = make([]byte, (int(v.Length) * 4))
 	copy(v.Data[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -3251,7 +3238,6 @@ func getColorTableParameterfvReply(buf []byte) *GetColorTableParameterfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -3363,7 +3349,6 @@ func getColorTableParameterivReply(buf []byte) *GetColorTableParameterivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -3468,7 +3453,7 @@ func getCompressedTexImageARBReply(buf []byte) *GetCompressedTexImageARBReply {
 
 	v.Data = make([]byte, (int(v.Length) * 4))
 	copy(v.Data[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -3577,7 +3562,7 @@ func getConvolutionFilterReply(buf []byte) *GetConvolutionFilterReply {
 
 	v.Data = make([]byte, (int(v.Length) * 4))
 	copy(v.Data[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -3699,7 +3684,6 @@ func getConvolutionParameterfvReply(buf []byte) *GetConvolutionParameterfvReply 
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -3811,7 +3795,6 @@ func getConvolutionParameterivReply(buf []byte) *GetConvolutionParameterivReply 
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -3923,7 +3906,6 @@ func getDoublevReply(buf []byte) *GetDoublevReply {
 		v.Data[i] = Float64(xgb.Get64(buf[b:]))
 		b += 8
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -4025,7 +4007,6 @@ func getDrawableAttributesReply(buf []byte) *GetDrawableAttributesReply {
 		v.Attribs[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -4216,7 +4197,6 @@ func getFBConfigsReply(buf []byte) *GetFBConfigsReply {
 		v.PropertyList[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -4322,7 +4302,6 @@ func getFloatvReply(buf []byte) *GetFloatvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -4424,7 +4403,7 @@ func getHistogramReply(buf []byte) *GetHistogramReply {
 
 	v.Data = make([]byte, (int(v.Length) * 4))
 	copy(v.Data[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -4553,7 +4532,6 @@ func getHistogramParameterfvReply(buf []byte) *GetHistogramParameterfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -4665,7 +4643,6 @@ func getHistogramParameterivReply(buf []byte) *GetHistogramParameterivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -4777,7 +4754,6 @@ func getIntegervReply(buf []byte) *GetIntegervReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -4886,7 +4862,6 @@ func getLightfvReply(buf []byte) *GetLightfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -4998,7 +4973,6 @@ func getLightivReply(buf []byte) *GetLightivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -5110,7 +5084,6 @@ func getMapdvReply(buf []byte) *GetMapdvReply {
 		v.Data[i] = Float64(xgb.Get64(buf[b:]))
 		b += 8
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -5222,7 +5195,6 @@ func getMapfvReply(buf []byte) *GetMapfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -5334,7 +5306,6 @@ func getMapivReply(buf []byte) *GetMapivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -5446,7 +5417,6 @@ func getMaterialfvReply(buf []byte) *GetMaterialfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -5558,7 +5528,6 @@ func getMaterialivReply(buf []byte) *GetMaterialivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -5656,7 +5625,7 @@ func getMinmaxReply(buf []byte) *GetMinmaxReply {
 
 	v.Data = make([]byte, (int(v.Length) * 4))
 	copy(v.Data[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -5785,7 +5754,6 @@ func getMinmaxParameterfvReply(buf []byte) *GetMinmaxParameterfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -5897,7 +5865,6 @@ func getMinmaxParameterivReply(buf []byte) *GetMinmaxParameterivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -6009,7 +5976,6 @@ func getPixelMapfvReply(buf []byte) *GetPixelMapfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -6118,7 +6084,6 @@ func getPixelMapuivReply(buf []byte) *GetPixelMapuivReply {
 		v.Data[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -6227,7 +6192,6 @@ func getPixelMapusvReply(buf []byte) *GetPixelMapusvReply {
 		v.Data[i] = xgb.Get16(buf[b:])
 		b += 2
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -6322,7 +6286,7 @@ func getPolygonStippleReply(buf []byte) *GetPolygonStippleReply {
 
 	v.Data = make([]byte, (int(v.Length) * 4))
 	copy(v.Data[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -6435,7 +6399,6 @@ func getQueryObjectivARBReply(buf []byte) *GetQueryObjectivARBReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -6547,7 +6510,6 @@ func getQueryObjectuivARBReply(buf []byte) *GetQueryObjectuivARBReply {
 		v.Data[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -6659,7 +6621,6 @@ func getQueryivARBReply(buf []byte) *GetQueryivARBReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -6768,7 +6729,7 @@ func getSeparableFilterReply(buf []byte) *GetSeparableFilterReply {
 
 	v.RowsAndCols = make([]byte, (int(v.Length) * 4))
 	copy(v.RowsAndCols[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -6995,7 +6956,6 @@ func getTexEnvfvReply(buf []byte) *GetTexEnvfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -7107,7 +7067,6 @@ func getTexEnvivReply(buf []byte) *GetTexEnvivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -7219,7 +7178,6 @@ func getTexGendvReply(buf []byte) *GetTexGendvReply {
 		v.Data[i] = Float64(xgb.Get64(buf[b:]))
 		b += 8
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -7331,7 +7289,6 @@ func getTexGenfvReply(buf []byte) *GetTexGenfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -7443,7 +7400,6 @@ func getTexGenivReply(buf []byte) *GetTexGenivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -7556,7 +7512,7 @@ func getTexImageReply(buf []byte) *GetTexImageReply {
 
 	v.Data = make([]byte, (int(v.Length) * 4))
 	copy(v.Data[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -7681,7 +7637,6 @@ func getTexLevelParameterfvReply(buf []byte) *GetTexLevelParameterfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -7796,7 +7751,6 @@ func getTexLevelParameterivReply(buf []byte) *GetTexLevelParameterivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -7911,7 +7865,6 @@ func getTexParameterfvReply(buf []byte) *GetTexParameterfvReply {
 		v.Data[i] = Float32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -8023,7 +7976,6 @@ func getTexParameterivReply(buf []byte) *GetTexParameterivReply {
 		v.Data[i] = int32(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -8132,7 +8084,6 @@ func getVisualConfigsReply(buf []byte) *GetVisualConfigsReply {
 		v.PropertyList[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -8979,7 +8930,6 @@ func queryContextReply(buf []byte) *QueryContextReply {
 		v.Attribs[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -9368,7 +9318,7 @@ func readPixelsReply(buf []byte) *ReadPixelsReply {
 
 	v.Data = make([]byte, (int(v.Length) * 4))
 	copy(v.Data[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -9480,7 +9430,7 @@ func renderRequest(c *xgb.Conn, ContextTag ContextTag, Data []byte) []byte {
 	b += 4
 
 	copy(buf[b:], Data[:len(Data)])
-	b += xgb.Pad(int(len(Data)))
+	b += int(len(Data))
 
 	return buf
 }
@@ -9547,7 +9497,7 @@ func renderLargeRequest(c *xgb.Conn, ContextTag ContextTag, RequestNum uint16, R
 	b += 4
 
 	copy(buf[b:], Data[:DataLen])
-	b += xgb.Pad(int(DataLen))
+	b += int(DataLen)
 
 	return buf
 }
@@ -9632,7 +9582,6 @@ func renderModeReply(buf []byte) *RenderModeReply {
 		v.Data[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -9788,13 +9737,12 @@ func setClientInfo2ARBRequest(c *xgb.Conn, MajorVersion uint32, MinorVersion uin
 		xgb.Put32(buf[b:], GlVersions[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	copy(buf[b:], GlExtensionString[:GlStrLen])
-	b += xgb.Pad(int(GlStrLen))
+	b += int(GlStrLen)
 
 	copy(buf[b:], GlxExtensionString[:GlxStrLen])
-	b += xgb.Pad(int(GlxStrLen))
+	b += int(GlxStrLen)
 
 	return buf
 }
@@ -9867,13 +9815,12 @@ func setClientInfoARBRequest(c *xgb.Conn, MajorVersion uint32, MinorVersion uint
 		xgb.Put32(buf[b:], GlVersions[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	copy(buf[b:], GlExtensionString[:GlStrLen])
-	b += xgb.Pad(int(GlStrLen))
+	b += int(GlStrLen)
 
 	copy(buf[b:], GlxExtensionString[:GlxStrLen])
-	b += xgb.Pad(int(GlxStrLen))
+	b += int(GlxStrLen)
 
 	return buf
 }
@@ -10059,7 +10006,7 @@ func vendorPrivateRequest(c *xgb.Conn, VendorCode uint32, ContextTag ContextTag,
 	b += 4
 
 	copy(buf[b:], Data[:len(Data)])
-	b += xgb.Pad(int(len(Data)))
+	b += int(len(Data))
 
 	return buf
 }
@@ -10131,11 +10078,11 @@ func vendorPrivateWithReplyReply(buf []byte) *VendorPrivateWithReplyReply {
 
 	v.Data1 = make([]byte, 24)
 	copy(v.Data1[:24], buf[b:])
-	b += xgb.Pad(int(24))
+	b += int(24)
 
 	v.Data2 = make([]byte, (int(v.Length) * 4))
 	copy(v.Data2[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -10163,7 +10110,7 @@ func vendorPrivateWithReplyRequest(c *xgb.Conn, VendorCode uint32, ContextTag Co
 	b += 4
 
 	copy(buf[b:], Data[:len(Data)])
-	b += xgb.Pad(int(len(Data)))
+	b += int(len(Data))
 
 	return buf
 }

--- a/render/render.go
+++ b/render/render.go
@@ -76,7 +76,7 @@ func (v Animcursorelt) Bytes() []byte {
 	xgb.Put32(buf[b:], v.Delay)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // AnimcursoreltListBytes writes a list of Animcursorelt values to a byte slice.
@@ -144,7 +144,7 @@ func (v Color) Bytes() []byte {
 	xgb.Put16(buf[b:], v.Alpha)
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // ColorListBytes writes a list of Color values to a byte slice.
@@ -256,7 +256,7 @@ func (v Directformat) Bytes() []byte {
 	xgb.Put16(buf[b:], v.AlphaMask)
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // DirectformatListBytes writes a list of Directformat values to a byte slice.
@@ -434,7 +434,7 @@ func (v Glyphinfo) Bytes() []byte {
 	xgb.Put16(buf[b:], uint16(v.YOff))
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // GlyphinfoListBytes writes a list of Glyphinfo values to a byte slice.
@@ -519,7 +519,7 @@ func (v Indexvalue) Bytes() []byte {
 	xgb.Put16(buf[b:], v.Alpha)
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // IndexvalueListBytes writes a list of Indexvalue values to a byte slice.
@@ -579,7 +579,7 @@ func (v Linefix) Bytes() []byte {
 		b += len(structBytes)
 	}
 
-	return buf
+	return buf[:b]
 }
 
 // LinefixListBytes writes a list of Linefix values to a byte slice.
@@ -802,7 +802,7 @@ func (v Pictdepth) Bytes() []byte {
 
 	b += PictvisualListBytes(buf[b:], v.Visuals)
 
-	return buf
+	return buf[:b]
 }
 
 // PictdepthListBytes writes a list of Pictdepth values to a byte slice.
@@ -904,7 +904,7 @@ func (v Pictforminfo) Bytes() []byte {
 	xgb.Put32(buf[b:], uint32(v.Colormap))
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // PictforminfoListBytes writes a list of Pictforminfo values to a byte slice.
@@ -964,7 +964,7 @@ func (v Pictscreen) Bytes() []byte {
 
 	b += PictdepthListBytes(buf[b:], v.Depths)
 
-	return buf
+	return buf[:b]
 }
 
 // PictscreenListBytes writes a list of Pictscreen values to a byte slice.
@@ -1087,7 +1087,7 @@ func (v Pictvisual) Bytes() []byte {
 	xgb.Put32(buf[b:], uint32(v.Format))
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // PictvisualListBytes writes a list of Pictvisual values to a byte slice.
@@ -1141,7 +1141,7 @@ func (v Pointfix) Bytes() []byte {
 	xgb.Put32(buf[b:], uint32(v.Y))
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // PointfixListBytes writes a list of Pointfix values to a byte slice.
@@ -1219,7 +1219,7 @@ func (v Spanfix) Bytes() []byte {
 	xgb.Put32(buf[b:], uint32(v.Y))
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // SpanfixListBytes writes a list of Spanfix values to a byte slice.
@@ -1331,7 +1331,7 @@ func (v Transform) Bytes() []byte {
 	xgb.Put32(buf[b:], uint32(v.Matrix33))
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // TransformListBytes writes a list of Transform values to a byte slice.
@@ -1391,7 +1391,7 @@ func (v Trap) Bytes() []byte {
 		b += len(structBytes)
 	}
 
-	return buf
+	return buf[:b]
 }
 
 // TrapListBytes writes a list of Trap values to a byte slice.
@@ -1465,7 +1465,7 @@ func (v Trapezoid) Bytes() []byte {
 		b += len(structBytes)
 	}
 
-	return buf
+	return buf[:b]
 }
 
 // TrapezoidListBytes writes a list of Trapezoid values to a byte slice.
@@ -1535,7 +1535,7 @@ func (v Triangle) Bytes() []byte {
 		b += len(structBytes)
 	}
 
-	return buf
+	return buf[:b]
 }
 
 // TriangleListBytes writes a list of Triangle values to a byte slice.
@@ -1610,7 +1610,7 @@ func (cook AddGlyphsCookie) Check() error {
 // Write request to wire for AddGlyphs
 // addGlyphsRequest writes a AddGlyphs request to a byte slice.
 func addGlyphsRequest(c *xgb.Conn, Glyphset Glyphset, GlyphsLen uint32, Glyphids []uint32, Glyphs []Glyphinfo, Data []byte) []byte {
-	size := xgb.Pad((((12 + xgb.Pad((int(GlyphsLen) * 4))) + xgb.Pad((int(GlyphsLen) * 12))) + xgb.Pad((len(Data) * 1))))
+	size := xgb.Pad(((((12 + xgb.Pad((int(GlyphsLen) * 4))) + 4) + xgb.Pad((int(GlyphsLen) * 12))) + xgb.Pad((len(Data) * 1))))
 	b := 0
 	buf := make([]byte, size)
 
@@ -1620,7 +1620,7 @@ func addGlyphsRequest(c *xgb.Conn, Glyphset Glyphset, GlyphsLen uint32, Glyphids
 	buf[b] = 20 // request opcode
 	b += 1
 
-	xgb.Put16(buf[b:], uint16(size/4)) // write request size in 4-byte units
+	blen := b
 	b += 2
 
 	xgb.Put32(buf[b:], uint32(Glyphset))
@@ -1633,14 +1633,17 @@ func addGlyphsRequest(c *xgb.Conn, Glyphset Glyphset, GlyphsLen uint32, Glyphids
 		xgb.Put32(buf[b:], Glyphids[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	b += GlyphinfoListBytes(buf[b:], Glyphs)
 
 	copy(buf[b:], Data[:len(Data)])
-	b += xgb.Pad(int(len(Data)))
+	b += int(len(Data))
 
-	return buf
+	b = xgb.Pad(b)
+	xgb.Put16(buf[blen:], uint16(b/4)) // write request size in 4-byte units
+	return buf[:b]
 }
 
 // AddTrapsCookie is a cookie used only for AddTraps requests.
@@ -1932,7 +1935,7 @@ func compositeGlyphs16Request(c *xgb.Conn, Op byte, Src Picture, Dst Picture, Ma
 	b += 2
 
 	copy(buf[b:], Glyphcmds[:len(Glyphcmds)])
-	b += xgb.Pad(int(len(Glyphcmds)))
+	b += int(len(Glyphcmds))
 
 	return buf
 }
@@ -2010,7 +2013,7 @@ func compositeGlyphs32Request(c *xgb.Conn, Op byte, Src Picture, Dst Picture, Ma
 	b += 2
 
 	copy(buf[b:], Glyphcmds[:len(Glyphcmds)])
-	b += xgb.Pad(int(len(Glyphcmds)))
+	b += int(len(Glyphcmds))
 
 	return buf
 }
@@ -2088,7 +2091,7 @@ func compositeGlyphs8Request(c *xgb.Conn, Op byte, Src Picture, Dst Picture, Mas
 	b += 2
 
 	copy(buf[b:], Glyphcmds[:len(Glyphcmds)])
-	b += xgb.Pad(int(len(Glyphcmds)))
+	b += int(len(Glyphcmds))
 
 	return buf
 }
@@ -2186,7 +2189,7 @@ func (cook CreateConicalGradientCookie) Check() error {
 // Write request to wire for CreateConicalGradient
 // createConicalGradientRequest writes a CreateConicalGradient request to a byte slice.
 func createConicalGradientRequest(c *xgb.Conn, Picture Picture, Center Pointfix, Angle Fixed, NumStops uint32, Stops []Fixed, Colors []Color) []byte {
-	size := xgb.Pad(((24 + xgb.Pad((int(NumStops) * 4))) + xgb.Pad((int(NumStops) * 8))))
+	size := xgb.Pad((((24 + xgb.Pad((int(NumStops) * 4))) + 4) + xgb.Pad((int(NumStops) * 8))))
 	b := 0
 	buf := make([]byte, size)
 
@@ -2196,7 +2199,7 @@ func createConicalGradientRequest(c *xgb.Conn, Picture Picture, Center Pointfix,
 	buf[b] = 36 // request opcode
 	b += 1
 
-	xgb.Put16(buf[b:], uint16(size/4)) // write request size in 4-byte units
+	blen := b
 	b += 2
 
 	xgb.Put32(buf[b:], uint32(Picture))
@@ -2218,11 +2221,14 @@ func createConicalGradientRequest(c *xgb.Conn, Picture Picture, Center Pointfix,
 		xgb.Put32(buf[b:], uint32(Stops[i]))
 		b += 4
 	}
-	b = xgb.Pad(b)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	b += ColorListBytes(buf[b:], Colors)
 
-	return buf
+	b = xgb.Pad(b)
+	xgb.Put16(buf[blen:], uint16(b/4)) // write request size in 4-byte units
+	return buf[:b]
 }
 
 // CreateCursorCookie is a cookie used only for CreateCursor requests.
@@ -2383,7 +2389,7 @@ func (cook CreateLinearGradientCookie) Check() error {
 // Write request to wire for CreateLinearGradient
 // createLinearGradientRequest writes a CreateLinearGradient request to a byte slice.
 func createLinearGradientRequest(c *xgb.Conn, Picture Picture, P1 Pointfix, P2 Pointfix, NumStops uint32, Stops []Fixed, Colors []Color) []byte {
-	size := xgb.Pad(((28 + xgb.Pad((int(NumStops) * 4))) + xgb.Pad((int(NumStops) * 8))))
+	size := xgb.Pad((((28 + xgb.Pad((int(NumStops) * 4))) + 4) + xgb.Pad((int(NumStops) * 8))))
 	b := 0
 	buf := make([]byte, size)
 
@@ -2393,7 +2399,7 @@ func createLinearGradientRequest(c *xgb.Conn, Picture Picture, P1 Pointfix, P2 P
 	buf[b] = 34 // request opcode
 	b += 1
 
-	xgb.Put16(buf[b:], uint16(size/4)) // write request size in 4-byte units
+	blen := b
 	b += 2
 
 	xgb.Put32(buf[b:], uint32(Picture))
@@ -2418,11 +2424,14 @@ func createLinearGradientRequest(c *xgb.Conn, Picture Picture, P1 Pointfix, P2 P
 		xgb.Put32(buf[b:], uint32(Stops[i]))
 		b += 4
 	}
-	b = xgb.Pad(b)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	b += ColorListBytes(buf[b:], Colors)
 
-	return buf
+	b = xgb.Pad(b)
+	xgb.Put16(buf[blen:], uint16(b/4)) // write request size in 4-byte units
+	return buf[:b]
 }
 
 // CreatePictureCookie is a cookie used only for CreatePicture requests.
@@ -2530,7 +2539,7 @@ func (cook CreateRadialGradientCookie) Check() error {
 // Write request to wire for CreateRadialGradient
 // createRadialGradientRequest writes a CreateRadialGradient request to a byte slice.
 func createRadialGradientRequest(c *xgb.Conn, Picture Picture, Inner Pointfix, Outer Pointfix, InnerRadius Fixed, OuterRadius Fixed, NumStops uint32, Stops []Fixed, Colors []Color) []byte {
-	size := xgb.Pad(((36 + xgb.Pad((int(NumStops) * 4))) + xgb.Pad((int(NumStops) * 8))))
+	size := xgb.Pad((((36 + xgb.Pad((int(NumStops) * 4))) + 4) + xgb.Pad((int(NumStops) * 8))))
 	b := 0
 	buf := make([]byte, size)
 
@@ -2540,7 +2549,7 @@ func createRadialGradientRequest(c *xgb.Conn, Picture Picture, Inner Pointfix, O
 	buf[b] = 35 // request opcode
 	b += 1
 
-	xgb.Put16(buf[b:], uint16(size/4)) // write request size in 4-byte units
+	blen := b
 	b += 2
 
 	xgb.Put32(buf[b:], uint32(Picture))
@@ -2571,11 +2580,14 @@ func createRadialGradientRequest(c *xgb.Conn, Picture Picture, Inner Pointfix, O
 		xgb.Put32(buf[b:], uint32(Stops[i]))
 		b += 4
 	}
-	b = xgb.Pad(b)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	b += ColorListBytes(buf[b:], Colors)
 
-	return buf
+	b = xgb.Pad(b)
+	xgb.Put16(buf[blen:], uint16(b/4)) // write request size in 4-byte units
+	return buf[:b]
 }
 
 // CreateSolidFillCookie is a cookie used only for CreateSolidFill requests.
@@ -2818,7 +2830,6 @@ func freeGlyphsRequest(c *xgb.Conn, Glyphset Glyphset, Glyphs []Glyph) []byte {
 		xgb.Put32(buf[b:], uint32(Glyphs[i]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -2955,7 +2966,6 @@ func queryFiltersReply(buf []byte) *QueryFiltersReply {
 		v.Aliases[i] = xgb.Get16(buf[b:])
 		b += 2
 	}
-	b = xgb.Pad(b)
 
 	v.Filters = make([]xproto.Str, v.NumFilters)
 	b += xproto.StrReadList(buf[b:], v.Filters)
@@ -3023,9 +3033,11 @@ type QueryPictFormatsReply struct {
 	NumVisuals  uint32
 	NumSubpixel uint32
 	// padding: 4 bytes
-	Formats   []Pictforminfo // size: xgb.Pad((int(NumFormats) * 28))
-	Screens   []Pictscreen   // size: PictscreenListSize(Screens)
-	Subpixels []uint32       // size: xgb.Pad((int(NumSubpixel) * 4))
+	Formats []Pictforminfo // size: xgb.Pad((int(NumFormats) * 28))
+	// alignment gap to multiple of 4
+	Screens []Pictscreen // size: PictscreenListSize(Screens)
+	// alignment gap to multiple of 4
+	Subpixels []uint32 // size: xgb.Pad((int(NumSubpixel) * 4))
 }
 
 // Reply blocks and returns the reply data for a QueryPictFormats request.
@@ -3073,15 +3085,18 @@ func queryPictFormatsReply(buf []byte) *QueryPictFormatsReply {
 	v.Formats = make([]Pictforminfo, v.NumFormats)
 	b += PictforminfoReadList(buf[b:], v.Formats)
 
+	b = (b + 3) & ^3 // alignment gap
+
 	v.Screens = make([]Pictscreen, v.NumScreens)
 	b += PictscreenReadList(buf[b:], v.Screens)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	v.Subpixels = make([]uint32, v.NumSubpixel)
 	for i := 0; i < int(v.NumSubpixel); i++ {
 		v.Subpixels[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -3455,7 +3470,7 @@ func (cook SetPictureFilterCookie) Check() error {
 // Write request to wire for SetPictureFilter
 // setPictureFilterRequest writes a SetPictureFilter request to a byte slice.
 func setPictureFilterRequest(c *xgb.Conn, Picture Picture, FilterLen uint16, Filter string, Values []Fixed) []byte {
-	size := xgb.Pad(((12 + xgb.Pad((int(FilterLen) * 1))) + xgb.Pad((len(Values) * 4))))
+	size := xgb.Pad((((12 + xgb.Pad((int(FilterLen) * 1))) + 4) + xgb.Pad((len(Values) * 4))))
 	b := 0
 	buf := make([]byte, size)
 
@@ -3465,7 +3480,7 @@ func setPictureFilterRequest(c *xgb.Conn, Picture Picture, FilterLen uint16, Fil
 	buf[b] = 30 // request opcode
 	b += 1
 
-	xgb.Put16(buf[b:], uint16(size/4)) // write request size in 4-byte units
+	blen := b
 	b += 2
 
 	xgb.Put32(buf[b:], uint32(Picture))
@@ -3477,15 +3492,18 @@ func setPictureFilterRequest(c *xgb.Conn, Picture Picture, FilterLen uint16, Fil
 	b += 2 // padding
 
 	copy(buf[b:], Filter[:FilterLen])
-	b += xgb.Pad(int(FilterLen))
+	b += int(FilterLen)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	for i := 0; i < int(len(Values)); i++ {
 		xgb.Put32(buf[b:], uint32(Values[i]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
-	return buf
+	b = xgb.Pad(b)
+	xgb.Put16(buf[blen:], uint16(b/4)) // write request size in 4-byte units
+	return buf[:b]
 }
 
 // SetPictureTransformCookie is a cookie used only for SetPictureTransform requests.

--- a/res/res.go
+++ b/res/res.go
@@ -76,7 +76,7 @@ func (v Client) Bytes() []byte {
 	xgb.Put32(buf[b:], v.ResourceMask)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // ClientListBytes writes a list of Client values to a byte slice.
@@ -135,7 +135,7 @@ func (v ClientIdSpec) Bytes() []byte {
 	xgb.Put32(buf[b:], v.Mask)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // ClientIdSpecListBytes writes a list of ClientIdSpec values to a byte slice.
@@ -171,7 +171,6 @@ func ClientIdValueRead(buf []byte, v *ClientIdValue) int {
 		v.Value[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return b
 }
@@ -204,9 +203,8 @@ func (v ClientIdValue) Bytes() []byte {
 		xgb.Put32(buf[b:], v.Value[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
-	return buf
+	return buf[:b]
 }
 
 // ClientIdValueListBytes writes a list of ClientIdValue values to a byte slice.
@@ -269,7 +267,7 @@ func (v ResourceIdSpec) Bytes() []byte {
 	xgb.Put32(buf[b:], v.Type)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // ResourceIdSpecListBytes writes a list of ResourceIdSpec values to a byte slice.
@@ -340,7 +338,7 @@ func (v ResourceSizeSpec) Bytes() []byte {
 	xgb.Put32(buf[b:], v.UseCount)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // ResourceSizeSpecListBytes writes a list of ResourceSizeSpec values to a byte slice.
@@ -403,7 +401,7 @@ func (v ResourceSizeValue) Bytes() []byte {
 
 	b += ResourceSizeSpecListBytes(buf[b:], v.CrossReferences)
 
-	return buf
+	return buf[:b]
 }
 
 // ResourceSizeValueListBytes writes a list of ResourceSizeValue values to a byte slice.
@@ -466,7 +464,7 @@ func (v Type) Bytes() []byte {
 	xgb.Put32(buf[b:], v.Count)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // TypeListBytes writes a list of Type values to a byte slice.

--- a/xcmisc/xcmisc.go
+++ b/xcmisc/xcmisc.go
@@ -228,7 +228,6 @@ func getXIDListReply(buf []byte) *GetXIDListReply {
 		v.Ids[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }

--- a/xevie/xevie.go
+++ b/xevie/xevie.go
@@ -72,7 +72,7 @@ func (v Event) Bytes() []byte {
 
 	b += 32 // padding
 
-	return buf
+	return buf[:b]
 }
 
 // EventListBytes writes a list of Event values to a byte slice.

--- a/xfixes/xfixes.go
+++ b/xfixes/xfixes.go
@@ -489,7 +489,7 @@ func changeCursorByNameRequest(c *xgb.Conn, Src xproto.Cursor, Nbytes uint16, Na
 	b += 2 // padding
 
 	copy(buf[b:], Name[:Nbytes])
-	b += xgb.Pad(int(Nbytes))
+	b += int(Nbytes)
 
 	return buf
 }
@@ -697,7 +697,6 @@ func createPointerBarrierRequest(c *xgb.Conn, Barrier Barrier, Window xproto.Win
 		xgb.Put16(buf[b:], Devices[i])
 		b += 2
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1367,7 +1366,6 @@ func getCursorImageReply(buf []byte) *GetCursorImageReply {
 		v.CursorImage[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -1433,7 +1431,8 @@ type GetCursorImageAndNameReply struct {
 	CursorAtom   xproto.Atom
 	Nbytes       uint16
 	// padding: 2 bytes
-	Name        string   // size: xgb.Pad((int(Nbytes) * 1))
+	Name string // size: xgb.Pad((int(Nbytes) * 1))
+	// alignment gap to multiple of 4
 	CursorImage []uint32 // size: xgb.Pad(((int(Width) * int(Height)) * 4))
 }
 
@@ -1498,12 +1497,13 @@ func getCursorImageAndNameReply(buf []byte) *GetCursorImageAndNameReply {
 		b += int(v.Nbytes)
 	}
 
+	b = (b + 3) & ^3 // alignment gap
+
 	v.CursorImage = make([]uint32, (int(v.Width) * int(v.Height)))
 	for i := 0; i < int((int(v.Width) * int(v.Height))); i++ {
 		v.CursorImage[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -2143,7 +2143,7 @@ func setCursorNameRequest(c *xgb.Conn, Cursor xproto.Cursor, Nbytes uint16, Name
 	b += 2 // padding
 
 	copy(buf[b:], Name[:Nbytes])
-	b += xgb.Pad(int(Nbytes))
+	b += int(Nbytes)
 
 	return buf
 }

--- a/xgbgen/aligngap.go
+++ b/xgbgen/aligngap.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func (p *Protocol) AddAlignGaps() {
+	for i := range p.Imports {
+		p.Imports[i].AddAlignGaps()
+	}
+	for i := range p.Types {
+		switch t := p.Types[i].(type) {
+		case *Struct:
+			t.Fields = addAlignGapsToFields(t.xmlName, t.Fields)
+		case *Event:
+			t.Fields = addAlignGapsToFields(t.xmlName, t.Fields)
+		case *Error:
+			t.Fields = addAlignGapsToFields(t.xmlName, t.Fields)
+		}
+	}
+	for i := range p.Requests {
+		p.Requests[i].Fields = addAlignGapsToFields(p.Requests[i].xmlName, p.Requests[i].Fields)
+		if p.Requests[i].Reply != nil {
+			p.Requests[i].Reply.Fields = addAlignGapsToFields(p.Requests[i].xmlName, p.Requests[i].Reply.Fields)
+		}
+	}
+}
+
+func addAlignGapsToFields(name string, fields []Field) []Field {
+	var i int
+	for i = 0; i < len(fields); i++ {
+		if _, ok := fields[i].(*ListField); ok {
+			break
+		}
+	}
+	if i >= len(fields) {
+		return fields
+	}
+
+	r := make([]Field, 0, len(fields)+2)
+	r = append(r, fields[:i]...)
+
+	r = append(r, fields[i])
+	for i = i + 1; i < len(fields); i++ {
+		switch f := fields[i].(type) {
+		case *ListField:
+			// ok, add padding
+			sz := xcbSizeOfType(f.Type)
+			switch {
+			case sz == 1:
+				// nothing
+			case sz == 2:
+				r = append(r, &PadField{0, 2})
+			case sz == 3:
+				panic(fmt.Errorf("Alignment is not a power of 2"))
+			case sz >= 4:
+				r = append(r, &PadField{0, 4})
+			}
+
+		case *LocalField:
+			// nothing
+
+		default:
+			fmt.Fprintf(os.Stderr, "Can't add alignment gaps, mix of list and non-list fields: %s\n", name)
+			return fields
+		}
+		r = append(r, fields[i])
+	}
+
+	return r
+}
+
+func xcbSizeOfField(fld Field) int {
+	switch f := fld.(type) {
+	case *PadField:
+		return int(f.Bytes)
+
+	case *SingleField:
+		return xcbSizeOfType(f.Type)
+
+	case *ListField:
+		return 0
+
+	case *ExprField:
+		return xcbSizeOfType(f.Type)
+
+	case *ValueField:
+		return xcbSizeOfType(f.MaskType)
+
+	case *SwitchField:
+		return 0
+
+	default:
+		return 0
+	}
+}
+
+func xcbSizeOfType(typ Type) int {
+	switch t := typ.(type) {
+	case *Resource:
+		return 4
+
+	case *TypeDef:
+		return t.Size().Eval()
+
+	case *Base:
+		return t.Size().Eval()
+
+	case *Struct:
+		sz := 0
+		for i := range t.Fields {
+			sz += xcbSizeOfField(t.Fields[i])
+		}
+		return sz
+
+	case *Union:
+		sz := 0
+		for i := range t.Fields {
+			csz := xcbSizeOfField(t.Fields[i])
+			if csz > sz {
+				sz = csz
+			}
+		}
+		return sz
+
+	default:
+		return 0
+	}
+}

--- a/xgbgen/context.go
+++ b/xgbgen/context.go
@@ -50,6 +50,8 @@ func (c *Context) Morph(xmlBytes []byte) {
 	// Translate XML types to nice types
 	c.protocol = parsedXml.Translate(nil)
 
+	c.protocol.AddAlignGaps()
+
 	// Start with Go header.
 	c.Putln("// Package %s is the X client API for the %s extension.",
 		c.protocol.PkgName(), c.protocol.ExtXName)

--- a/xgbgen/go.go
+++ b/xgbgen/go.go
@@ -103,15 +103,27 @@ func (td *TypeDef) Define(c *Context) {
 
 // Pad fields
 func (f *PadField) Define(c *Context) {
-	c.Putln("// padding: %d bytes", f.Bytes)
+	if f.Align > 0 {
+		c.Putln("// alignment gap to multiple of %d", f.Align)
+	} else {
+		c.Putln("// padding: %d bytes", f.Bytes)
+	}
 }
 
 func (f *PadField) Read(c *Context, prefix string) {
-	c.Putln("b += %s // padding", f.Size())
+	if f.Align > 0 {
+		c.Putln("b = (b + %d) & ^%d // alignment gap", f.Align-1, f.Align-1)
+	} else {
+		c.Putln("b += %s // padding", f.Size())
+	}
 }
 
 func (f *PadField) Write(c *Context, prefix string) {
-	c.Putln("b += %s // padding", f.Size())
+	if f.Align > 0 {
+		c.Putln("b = (b + %d) & ^%d // alignment gap", f.Align-1, f.Align-1)
+	} else {
+		c.Putln("b += %s // padding", f.Size())
+	}
 }
 
 // Local fields

--- a/xgbgen/go_list.go
+++ b/xgbgen/go_list.go
@@ -21,7 +21,6 @@ func (f *ListField) Read(c *Context, prefix string) {
 		c.Putln("for i := 0; i < int(%s); i++ {", length)
 		ReadSimpleSingleField(c, fmt.Sprintf("%s%s[i]", prefix, f.SrcName()), t)
 		c.Putln("}")
-		c.Putln("b = xgb.Pad(b)")
 	case *Base:
 		length := f.LengthExpr.Reduce(prefix)
 		if strings.ToLower(t.XmlName()) == "char" {
@@ -38,7 +37,7 @@ func (f *ListField) Read(c *Context, prefix string) {
 			c.Putln("%s%s = make([]%s, %s)",
 				prefix, f.SrcName(), t.SrcName(), length)
 			c.Putln("copy(%s%s[:%s], buf[b:])", prefix, f.SrcName(), length)
-			c.Putln("b += xgb.Pad(int(%s))", length)
+			c.Putln("b += int(%s)", length)
 		} else {
 			c.Putln("%s%s = make([]%s, %s)",
 				prefix, f.SrcName(), t.SrcName(), length)
@@ -46,7 +45,6 @@ func (f *ListField) Read(c *Context, prefix string) {
 			ReadSimpleSingleField(c,
 				fmt.Sprintf("%s%s[i]", prefix, f.SrcName()), t)
 			c.Putln("}")
-			c.Putln("b = xgb.Pad(b)")
 		}
 	case *TypeDef:
 		length := f.LengthExpr.Reduce(prefix)
@@ -55,7 +53,6 @@ func (f *ListField) Read(c *Context, prefix string) {
 		c.Putln("for i := 0; i < int(%s); i++ {", length)
 		ReadSimpleSingleField(c, fmt.Sprintf("%s%s[i]", prefix, f.SrcName()), t)
 		c.Putln("}")
-		c.Putln("b = xgb.Pad(b)")
 	case *Union:
 		c.Putln("%s%s = make([]%s, %s)",
 			prefix, f.SrcName(), t.SrcName(), f.LengthExpr.Reduce(prefix))
@@ -80,18 +77,16 @@ func (f *ListField) Write(c *Context, prefix string) {
 		WriteSimpleSingleField(c,
 			fmt.Sprintf("%s%s[i]", prefix, f.SrcName()), t)
 		c.Putln("}")
-		c.Putln("b = xgb.Pad(b)")
 	case *Base:
 		length := f.Length().Reduce(prefix)
 		if t.SrcName() == "byte" {
 			c.Putln("copy(buf[b:], %s%s[:%s])", prefix, f.SrcName(), length)
-			c.Putln("b += xgb.Pad(int(%s))", length)
+			c.Putln("b += int(%s)", length)
 		} else {
 			c.Putln("for i := 0; i < int(%s); i++ {", length)
 			WriteSimpleSingleField(c,
 				fmt.Sprintf("%s%s[i]", prefix, f.SrcName()), t)
 			c.Putln("}")
-			c.Putln("b = xgb.Pad(b)")
 		}
 	case *TypeDef:
 		length := f.Length().Reduce(prefix)
@@ -99,7 +94,6 @@ func (f *ListField) Write(c *Context, prefix string) {
 		WriteSimpleSingleField(c,
 			fmt.Sprintf("%s%s[i]", prefix, f.SrcName()), t)
 		c.Putln("}")
-		c.Putln("b = xgb.Pad(b)")
 	case *Union:
 		c.Putln("b += %sListBytes(buf[b:], %s%s)",
 			t.SrcName(), prefix, f.SrcName())

--- a/xgbgen/go_struct.go
+++ b/xgbgen/go_struct.go
@@ -78,7 +78,7 @@ func (s *Struct) Write(c *Context) {
 		field.Write(c, "v.")
 		c.Putln("")
 	}
-	c.Putln("return buf")
+	c.Putln("return buf[:b]")
 	c.Putln("}")
 	c.Putln("")
 }

--- a/xgbgen/request_reply.go
+++ b/xgbgen/request_reply.go
@@ -91,7 +91,7 @@ func (r *Request) CookieName() string {
 // If it's a core protocol request, then we only account for *three*
 // bytes of the header (remove the extension opcode).
 func (r *Request) Size(c *Context) Size {
-	size := newFixedSize(0)
+	size := newFixedSize(0, true)
 
 	// If this is a core protocol request, we squeeze in an extra byte of
 	// data (from the fields below) between the opcode and the size of the
@@ -99,9 +99,9 @@ func (r *Request) Size(c *Context) Size {
 	// by the opcode of the request (while the first byte is always occupied
 	// by the opcode of the extension).
 	if !c.protocol.isExt() {
-		size = size.Add(newFixedSize(3))
+		size = size.Add(newFixedSize(3, true))
 	} else {
-		size = size.Add(newFixedSize(4))
+		size = size.Add(newFixedSize(4, true))
 	}
 
 	for _, field := range r.Fields {
@@ -122,7 +122,7 @@ func (r *Request) Size(c *Context) Size {
 	}
 	return newExpressionSize(&Padding{
 		Expr: size.Expression,
-	})
+	}, size.exact)
 }
 
 // Reply encapsulates the fields associated with a 'reply' element.
@@ -136,10 +136,10 @@ type Reply struct {
 // 2 bytes: A sequence number
 // 4 bytes: Number of additional bytes in 4-byte units past initial 32 bytes.
 func (r *Reply) Size() Size {
-	size := newFixedSize(0)
+	size := newFixedSize(0, true)
 
 	// Account for reply discriminant, sequence number and reply length
-	size = size.Add(newFixedSize(7))
+	size = size.Add(newFixedSize(7, true))
 
 	for _, field := range r.Fields {
 		size = size.Add(field.Size())

--- a/xgbgen/size.go
+++ b/xgbgen/size.go
@@ -7,24 +7,25 @@ package main
 // for adding and multiplying sizes.
 type Size struct {
 	Expression
+	exact bool
 }
 
 // newFixedSize creates a new Size with some fixed and known value.
-func newFixedSize(fixed uint) Size {
-	return Size{&Value{v: int(fixed)}}
+func newFixedSize(fixed uint, exact bool) Size {
+	return Size{&Value{v: int(fixed)}, exact}
 }
 
 // newExpressionSize creates a new Size with some expression.
-func newExpressionSize(variable Expression) Size {
-	return Size{variable}
+func newExpressionSize(variable Expression, exact bool) Size {
+	return Size{variable, exact}
 }
 
 // Add adds s1 and s2 and returns a new Size.
 func (s1 Size) Add(s2 Size) Size {
-	return Size{newBinaryOp("+", s1, s2)}
+	return Size{newBinaryOp("+", s1, s2), s1.exact && s2.exact}
 }
 
 // Multiply mupltiplies s1 and s2 and returns a new Size.
 func (s1 Size) Multiply(s2 Size) Size {
-	return Size{newBinaryOp("*", s1, s2)}
+	return Size{newBinaryOp("*", s1, s2), s1.exact && s2.exact}
 }

--- a/xgbgen/translation.go
+++ b/xgbgen/translation.go
@@ -43,7 +43,7 @@ func (xml *XML) Translate(parent *Protocol) *Protocol {
 		newBaseType := &Base{
 			srcName: srcName,
 			xmlName: xmlName,
-			size:    newFixedSize(BaseTypeSizes[xmlName]),
+			size:    newFixedSize(BaseTypeSizes[xmlName], true),
 		}
 		protocol.Types = append(protocol.Types, newBaseType)
 	}

--- a/xgbgen/type.go
+++ b/xgbgen/type.go
@@ -154,7 +154,7 @@ func (r *Resource) XmlName() string {
 }
 
 func (r *Resource) Size() Size {
-	return newFixedSize(BaseTypeSizes["Id"])
+	return newFixedSize(BaseTypeSizes["Id"], true)
 }
 
 func (r *Resource) Initialize(p *Protocol) {
@@ -201,7 +201,7 @@ func (e *Event) XmlName() string {
 }
 
 func (e *Event) Size() Size {
-	return newExpressionSize(&Value{v: 32})
+	return newExpressionSize(&Value{v: 32}, true)
 }
 
 func (e *Event) Initialize(p *Protocol) {
@@ -231,7 +231,7 @@ func (e *EventCopy) XmlName() string {
 }
 
 func (e *EventCopy) Size() Size {
-	return newExpressionSize(&Value{v: 32})
+	return newExpressionSize(&Value{v: 32}, true)
 }
 
 func (e *EventCopy) Initialize(p *Protocol) {
@@ -262,7 +262,7 @@ func (e *Error) XmlName() string {
 }
 
 func (e *Error) Size() Size {
-	return newExpressionSize(&Value{v: 32})
+	return newExpressionSize(&Value{v: 32}, true)
 }
 
 func (e *Error) Initialize(p *Protocol) {
@@ -296,7 +296,7 @@ func (e *ErrorCopy) XmlName() string {
 }
 
 func (e *ErrorCopy) Size() Size {
-	return newExpressionSize(&Value{v: 32})
+	return newExpressionSize(&Value{v: 32}, true)
 }
 
 func (e *ErrorCopy) Initialize(p *Protocol) {
@@ -330,7 +330,7 @@ func (s *Struct) XmlName() string {
 }
 
 func (s *Struct) Size() Size {
-	size := newFixedSize(0)
+	size := newFixedSize(0, true)
 	for _, field := range s.Fields {
 		size = size.Add(field.Size())
 	}

--- a/xinerama/xinerama.go
+++ b/xinerama/xinerama.go
@@ -90,7 +90,7 @@ func (v ScreenInfo) Bytes() []byte {
 	xgb.Put16(buf[b:], v.Height)
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // ScreenInfoListBytes writes a list of ScreenInfo values to a byte slice.

--- a/xprint/xprint.go
+++ b/xprint/xprint.go
@@ -336,7 +336,6 @@ func PrinterRead(buf []byte, v *Printer) int {
 		v.Name[i] = String8(buf[b])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	v.DescLen = xgb.Get32(buf[b:])
 	b += 4
@@ -346,7 +345,6 @@ func PrinterRead(buf []byte, v *Printer) int {
 		v.Description[i] = String8(buf[b])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return b
 }
@@ -373,7 +371,6 @@ func (v Printer) Bytes() []byte {
 		buf[b] = byte(v.Name[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	xgb.Put32(buf[b:], v.DescLen)
 	b += 4
@@ -382,9 +379,8 @@ func (v Printer) Bytes() []byte {
 		buf[b] = byte(v.Description[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
-	return buf
+	return buf[:b]
 }
 
 // PrinterListBytes writes a list of Printer values to a byte slice.
@@ -496,13 +492,11 @@ func createContextRequest(c *xgb.Conn, ContextId uint32, PrinterNameLen uint32, 
 		buf[b] = byte(PrinterName[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	for i := 0; i < int(LocaleLen); i++ {
 		buf[b] = byte(Locale[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1003,7 +997,7 @@ func printGetDocumentDataReply(buf []byte) *PrintGetDocumentDataReply {
 
 	v.Data = make([]byte, v.DataLen)
 	copy(v.Data[:v.DataLen], buf[b:])
-	b += xgb.Pad(int(v.DataLen))
+	b += int(v.DataLen)
 
 	return v
 }
@@ -1193,7 +1187,6 @@ func printGetOneAttributesReply(buf []byte) *PrintGetOneAttributesReply {
 		v.Value[i] = String8(buf[b])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -1229,7 +1222,6 @@ func printGetOneAttributesRequest(c *xgb.Conn, Context Pcontext, NameLen uint32,
 		buf[b] = byte(Name[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1441,13 +1433,11 @@ func printGetPrinterListRequest(c *xgb.Conn, PrinterNameLen uint32, LocaleLen ui
 		buf[b] = byte(PrinterName[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	for i := 0; i < int(LocaleLen); i++ {
 		buf[b] = byte(Locale[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1707,19 +1697,17 @@ func printPutDocumentDataRequest(c *xgb.Conn, Drawable xproto.Drawable, LenData 
 	b += 2
 
 	copy(buf[b:], Data[:LenData])
-	b += xgb.Pad(int(LenData))
+	b += int(LenData)
 
 	for i := 0; i < int(len(DocFormat)); i++ {
 		buf[b] = byte(DocFormat[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	for i := 0; i < int(len(Options)); i++ {
 		buf[b] = byte(Options[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -1796,7 +1784,6 @@ func printQueryScreensReply(buf []byte) *PrintQueryScreensReply {
 		v.Roots[i] = xproto.Window(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -2091,7 +2078,6 @@ func printSetAttributesRequest(c *xgb.Conn, Context Pcontext, StringLen uint32, 
 		buf[b] = byte(Attributes[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }

--- a/xproto/xproto.go
+++ b/xproto/xproto.go
@@ -179,7 +179,7 @@ func (v Arc) Bytes() []byte {
 	xgb.Put16(buf[b:], uint16(v.Angle2))
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // ArcListBytes writes a list of Arc values to a byte slice.
@@ -603,7 +603,7 @@ func (v Char2b) Bytes() []byte {
 	buf[b] = v.Byte2
 	b += 1
 
-	return buf
+	return buf[:b]
 }
 
 // Char2bListBytes writes a list of Char2b values to a byte slice.
@@ -685,7 +685,7 @@ func (v Charinfo) Bytes() []byte {
 	xgb.Put16(buf[b:], v.Attributes)
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // CharinfoListBytes writes a list of Charinfo values to a byte slice.
@@ -932,7 +932,7 @@ func ClientMessageDataUnionData8New(Data8 []byte) ClientMessageDataUnion {
 	buf := make([]byte, 20)
 
 	copy(buf[b:], Data8[:20])
-	b += xgb.Pad(int(20))
+	b += int(20)
 
 	// Create the Union type
 	v := ClientMessageDataUnion{}
@@ -942,7 +942,7 @@ func ClientMessageDataUnionData8New(Data8 []byte) ClientMessageDataUnion {
 	b = 0 // always read the same bytes
 	v.Data8 = make([]byte, 20)
 	copy(v.Data8[:20], buf[b:])
-	b += xgb.Pad(int(20))
+	b += int(20)
 
 	b = 0 // always read the same bytes
 	v.Data16 = make([]uint16, 10)
@@ -950,7 +950,6 @@ func ClientMessageDataUnionData8New(Data8 []byte) ClientMessageDataUnion {
 		v.Data16[i] = xgb.Get16(buf[b:])
 		b += 2
 	}
-	b = xgb.Pad(b)
 
 	b = 0 // always read the same bytes
 	v.Data32 = make([]uint32, 5)
@@ -958,7 +957,6 @@ func ClientMessageDataUnionData8New(Data8 []byte) ClientMessageDataUnion {
 		v.Data32[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -972,7 +970,6 @@ func ClientMessageDataUnionData16New(Data16 []uint16) ClientMessageDataUnion {
 		xgb.Put16(buf[b:], Data16[i])
 		b += 2
 	}
-	b = xgb.Pad(b)
 
 	// Create the Union type
 	v := ClientMessageDataUnion{}
@@ -982,7 +979,7 @@ func ClientMessageDataUnionData16New(Data16 []uint16) ClientMessageDataUnion {
 	b = 0 // always read the same bytes
 	v.Data8 = make([]byte, 20)
 	copy(v.Data8[:20], buf[b:])
-	b += xgb.Pad(int(20))
+	b += int(20)
 
 	b = 0 // always read the same bytes
 	v.Data16 = make([]uint16, 10)
@@ -990,7 +987,6 @@ func ClientMessageDataUnionData16New(Data16 []uint16) ClientMessageDataUnion {
 		v.Data16[i] = xgb.Get16(buf[b:])
 		b += 2
 	}
-	b = xgb.Pad(b)
 
 	b = 0 // always read the same bytes
 	v.Data32 = make([]uint32, 5)
@@ -998,7 +994,6 @@ func ClientMessageDataUnionData16New(Data16 []uint16) ClientMessageDataUnion {
 		v.Data32[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -1012,7 +1007,6 @@ func ClientMessageDataUnionData32New(Data32 []uint32) ClientMessageDataUnion {
 		xgb.Put32(buf[b:], Data32[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	// Create the Union type
 	v := ClientMessageDataUnion{}
@@ -1022,7 +1016,7 @@ func ClientMessageDataUnionData32New(Data32 []uint32) ClientMessageDataUnion {
 	b = 0 // always read the same bytes
 	v.Data8 = make([]byte, 20)
 	copy(v.Data8[:20], buf[b:])
-	b += xgb.Pad(int(20))
+	b += int(20)
 
 	b = 0 // always read the same bytes
 	v.Data16 = make([]uint16, 10)
@@ -1030,7 +1024,6 @@ func ClientMessageDataUnionData32New(Data32 []uint32) ClientMessageDataUnion {
 		v.Data16[i] = xgb.Get16(buf[b:])
 		b += 2
 	}
-	b = xgb.Pad(b)
 
 	b = 0 // always read the same bytes
 	v.Data32 = make([]uint32, 5)
@@ -1038,7 +1031,6 @@ func ClientMessageDataUnionData32New(Data32 []uint32) ClientMessageDataUnion {
 		v.Data32[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -1050,7 +1042,7 @@ func ClientMessageDataUnionRead(buf []byte, v *ClientMessageDataUnion) int {
 	b = 0 // re-read the same bytes
 	v.Data8 = make([]byte, 20)
 	copy(v.Data8[:20], buf[b:])
-	b += xgb.Pad(int(20))
+	b += int(20)
 
 	b = 0 // re-read the same bytes
 	v.Data16 = make([]uint16, 10)
@@ -1058,7 +1050,6 @@ func ClientMessageDataUnionRead(buf []byte, v *ClientMessageDataUnion) int {
 		v.Data16[i] = xgb.Get16(buf[b:])
 		b += 2
 	}
-	b = xgb.Pad(b)
 
 	b = 0 // re-read the same bytes
 	v.Data32 = make([]uint32, 5)
@@ -1066,7 +1057,6 @@ func ClientMessageDataUnionRead(buf []byte, v *ClientMessageDataUnion) int {
 		v.Data32[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return 20
 }
@@ -1089,7 +1079,7 @@ func (v ClientMessageDataUnion) Bytes() []byte {
 	b := 0
 
 	copy(buf[b:], v.Data8[:20])
-	b += xgb.Pad(int(20))
+	b += int(20)
 	return buf
 }
 
@@ -1189,7 +1179,7 @@ func (v Coloritem) Bytes() []byte {
 
 	b += 1 // padding
 
-	return buf
+	return buf[:b]
 }
 
 // ColoritemListBytes writes a list of Coloritem values to a byte slice.
@@ -1908,7 +1898,7 @@ func (v DepthInfo) Bytes() []byte {
 
 	b += VisualInfoListBytes(buf[b:], v.Visuals)
 
-	return buf
+	return buf[:b]
 }
 
 // DepthInfoListBytes writes a list of DepthInfo values to a byte slice.
@@ -2580,7 +2570,7 @@ func (v Fontprop) Bytes() []byte {
 	xgb.Put32(buf[b:], v.Value)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // FontpropListBytes writes a list of Fontprop values to a byte slice.
@@ -2646,7 +2636,7 @@ func (v Format) Bytes() []byte {
 
 	b += 5 // padding
 
-	return buf
+	return buf[:b]
 }
 
 // FormatListBytes writes a list of Format values to a byte slice.
@@ -3072,7 +3062,7 @@ func HostRead(buf []byte, v *Host) int {
 
 	v.Address = make([]byte, v.AddressLen)
 	copy(v.Address[:v.AddressLen], buf[b:])
-	b += xgb.Pad(int(v.AddressLen))
+	b += int(v.AddressLen)
 
 	return b
 }
@@ -3101,9 +3091,9 @@ func (v Host) Bytes() []byte {
 	b += 2
 
 	copy(buf[b:], v.Address[:v.AddressLen])
-	b += xgb.Pad(int(v.AddressLen))
+	b += int(v.AddressLen)
 
-	return buf
+	return buf[:b]
 }
 
 // HostListBytes writes a list of Host values to a byte slice.
@@ -3469,7 +3459,7 @@ func KeymapNotifyEventNew(buf []byte) xgb.Event {
 
 	v.Keys = make([]byte, 31)
 	copy(v.Keys[:31], buf[b:])
-	b += xgb.Pad(int(31))
+	b += int(31)
 
 	return v
 }
@@ -3484,7 +3474,7 @@ func (v KeymapNotifyEvent) Bytes() []byte {
 	b += 1
 
 	copy(buf[b:], v.Keys[:31])
-	b += xgb.Pad(int(31))
+	b += int(31)
 
 	return buf
 }
@@ -4323,7 +4313,7 @@ func (v Point) Bytes() []byte {
 	xgb.Put16(buf[b:], uint16(v.Y))
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // PointListBytes writes a list of Point values to a byte slice.
@@ -4506,7 +4496,7 @@ func (v Rectangle) Bytes() []byte {
 	xgb.Put16(buf[b:], v.Height)
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // RectangleListBytes writes a list of Rectangle values to a byte slice.
@@ -4831,7 +4821,7 @@ func (v Rgb) Bytes() []byte {
 
 	b += 2 // padding
 
-	return buf
+	return buf[:b]
 }
 
 // RgbListBytes writes a list of Rgb values to a byte slice.
@@ -4997,7 +4987,7 @@ func (v ScreenInfo) Bytes() []byte {
 
 	b += DepthInfoListBytes(buf[b:], v.AllowedDepths)
 
-	return buf
+	return buf[:b]
 }
 
 // ScreenInfoListBytes writes a list of ScreenInfo values to a byte slice.
@@ -5079,7 +5069,7 @@ func (v Segment) Bytes() []byte {
 	xgb.Put16(buf[b:], uint16(v.Y2))
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // SegmentListBytes writes a list of Segment values to a byte slice.
@@ -5434,9 +5424,9 @@ func (v SetupAuthenticate) Bytes() []byte {
 	b += 2
 
 	copy(buf[b:], v.Reason[:(int(v.Length)*4)])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
-	return buf
+	return buf[:b]
 }
 
 // SetupAuthenticateListBytes writes a list of SetupAuthenticate values to a byte slice.
@@ -5529,9 +5519,9 @@ func (v SetupFailed) Bytes() []byte {
 	b += 2
 
 	copy(buf[b:], v.Reason[:v.ReasonLen])
-	b += xgb.Pad(int(v.ReasonLen))
+	b += int(v.ReasonLen)
 
-	return buf
+	return buf[:b]
 }
 
 // SetupFailedListBytes writes a list of SetupFailed values to a byte slice.
@@ -5576,9 +5566,11 @@ type SetupInfo struct {
 	MinKeycode               Keycode
 	MaxKeycode               Keycode
 	// padding: 4 bytes
-	Vendor        string       // size: xgb.Pad((int(VendorLen) * 1))
-	PixmapFormats []Format     // size: xgb.Pad((int(PixmapFormatsLen) * 8))
-	Roots         []ScreenInfo // size: ScreenInfoListSize(Roots)
+	Vendor string // size: xgb.Pad((int(VendorLen) * 1))
+	// alignment gap to multiple of 4
+	PixmapFormats []Format // size: xgb.Pad((int(PixmapFormatsLen) * 8))
+	// alignment gap to multiple of 4
+	Roots []ScreenInfo // size: ScreenInfoListSize(Roots)
 }
 
 // SetupInfoRead reads a byte slice into a SetupInfo value.
@@ -5650,8 +5642,12 @@ func SetupInfoRead(buf []byte, v *SetupInfo) int {
 		b += int(v.VendorLen)
 	}
 
+	b = (b + 3) & ^3 // alignment gap
+
 	v.PixmapFormats = make([]Format, v.PixmapFormatsLen)
 	b += FormatReadList(buf[b:], v.PixmapFormats)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	v.Roots = make([]ScreenInfo, v.RootsLen)
 	b += ScreenInfoReadList(buf[b:], v.Roots)
@@ -5671,7 +5667,7 @@ func SetupInfoReadList(buf []byte, dest []SetupInfo) int {
 
 // Bytes writes a SetupInfo value to a byte slice.
 func (v SetupInfo) Bytes() []byte {
-	buf := make([]byte, (((40 + xgb.Pad((int(v.VendorLen) * 1))) + xgb.Pad((int(v.PixmapFormatsLen) * 8))) + ScreenInfoListSize(v.Roots)))
+	buf := make([]byte, (((((40 + xgb.Pad((int(v.VendorLen) * 1))) + 4) + xgb.Pad((int(v.PixmapFormatsLen) * 8))) + 4) + ScreenInfoListSize(v.Roots)))
 	b := 0
 
 	buf[b] = v.Status
@@ -5733,13 +5729,17 @@ func (v SetupInfo) Bytes() []byte {
 	b += 4 // padding
 
 	copy(buf[b:], v.Vendor[:v.VendorLen])
-	b += xgb.Pad(int(v.VendorLen))
+	b += int(v.VendorLen)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	b += FormatListBytes(buf[b:], v.PixmapFormats)
 
+	b = (b + 3) & ^3 // alignment gap
+
 	b += ScreenInfoListBytes(buf[b:], v.Roots)
 
-	return buf
+	return buf[:b]
 }
 
 // SetupInfoListBytes writes a list of SetupInfo values to a byte slice.
@@ -5758,7 +5758,7 @@ func SetupInfoListBytes(buf []byte, list []SetupInfo) int {
 func SetupInfoListSize(list []SetupInfo) int {
 	size := 0
 	for _, item := range list {
-		size += (((40 + xgb.Pad((int(item.VendorLen) * 1))) + xgb.Pad((int(item.PixmapFormatsLen) * 8))) + ScreenInfoListSize(item.Roots))
+		size += (((((40 + xgb.Pad((int(item.VendorLen) * 1))) + 4) + xgb.Pad((int(item.PixmapFormatsLen) * 8))) + 4) + ScreenInfoListSize(item.Roots))
 	}
 	return size
 }
@@ -5850,12 +5850,12 @@ func (v SetupRequest) Bytes() []byte {
 	b += 2 // padding
 
 	copy(buf[b:], v.AuthorizationProtocolName[:v.AuthorizationProtocolNameLen])
-	b += xgb.Pad(int(v.AuthorizationProtocolNameLen))
+	b += int(v.AuthorizationProtocolNameLen)
 
 	copy(buf[b:], v.AuthorizationProtocolData[:v.AuthorizationProtocolDataLen])
-	b += xgb.Pad(int(v.AuthorizationProtocolDataLen))
+	b += int(v.AuthorizationProtocolDataLen)
 
-	return buf
+	return buf[:b]
 }
 
 // SetupRequestListBytes writes a list of SetupRequest values to a byte slice.
@@ -5928,9 +5928,9 @@ func (v Str) Bytes() []byte {
 	b += 1
 
 	copy(buf[b:], v.Name[:v.NameLen])
-	b += xgb.Pad(int(v.NameLen))
+	b += int(v.NameLen)
 
-	return buf
+	return buf[:b]
 }
 
 // StrListBytes writes a list of Str values to a byte slice.
@@ -6009,7 +6009,7 @@ func (v Timecoord) Bytes() []byte {
 	xgb.Put16(buf[b:], uint16(v.Y))
 	b += 2
 
-	return buf
+	return buf[:b]
 }
 
 // TimecoordListBytes writes a list of Timecoord values to a byte slice.
@@ -6352,7 +6352,7 @@ func (v VisualInfo) Bytes() []byte {
 
 	b += 4 // padding
 
-	return buf
+	return buf[:b]
 }
 
 // VisualInfoListBytes writes a list of VisualInfo values to a byte slice.
@@ -6588,7 +6588,8 @@ type AllocColorCellsReply struct {
 	MasksLen  uint16
 	// padding: 20 bytes
 	Pixels []uint32 // size: xgb.Pad((int(PixelsLen) * 4))
-	Masks  []uint32 // size: xgb.Pad((int(MasksLen) * 4))
+	// alignment gap to multiple of 4
+	Masks []uint32 // size: xgb.Pad((int(MasksLen) * 4))
 }
 
 // Reply blocks and returns the reply data for a AllocColorCells request.
@@ -6629,14 +6630,14 @@ func allocColorCellsReply(buf []byte) *AllocColorCellsReply {
 		v.Pixels[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	v.Masks = make([]uint32, v.MasksLen)
 	for i := 0; i < int(v.MasksLen); i++ {
 		v.Masks[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -6754,7 +6755,6 @@ func allocColorPlanesReply(buf []byte) *AllocColorPlanesReply {
 		v.Pixels[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -6905,7 +6905,7 @@ func allocNamedColorRequest(c *xgb.Conn, Cmap Colormap, NameLen uint16, Name str
 	b += 2 // padding
 
 	copy(buf[b:], Name[:NameLen])
-	b += xgb.Pad(int(NameLen))
+	b += int(NameLen)
 
 	return buf
 }
@@ -7169,7 +7169,7 @@ func changeHostsRequest(c *xgb.Conn, Mode byte, Family byte, AddressLen uint16, 
 	b += 2
 
 	copy(buf[b:], Address[:AddressLen])
-	b += xgb.Pad(int(AddressLen))
+	b += int(AddressLen)
 
 	return buf
 }
@@ -7282,7 +7282,6 @@ func changeKeyboardMappingRequest(c *xgb.Conn, KeycodeCount byte, FirstKeycode K
 		xgb.Put32(buf[b:], uint32(Keysyms[i]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -7416,7 +7415,7 @@ func changePropertyRequest(c *xgb.Conn, Mode byte, Window Window, Property Atom,
 	b += 4
 
 	copy(buf[b:], Data[:((int(DataLen)*int(Format))/8)])
-	b += xgb.Pad(int(((int(DataLen) * int(Format)) / 8)))
+	b += int(((int(DataLen) * int(Format)) / 8))
 
 	return buf
 }
@@ -8822,7 +8821,6 @@ func freeColorsRequest(c *xgb.Conn, Cmap Colormap, PlaneMask uint32, Pixels []ui
 		xgb.Put32(buf[b:], Pixels[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -9316,7 +9314,7 @@ func getImageReply(buf []byte) *GetImageReply {
 
 	v.Data = make([]byte, (int(v.Length) * 4))
 	copy(v.Data[:(int(v.Length)*4)], buf[b:])
-	b += xgb.Pad(int((int(v.Length) * 4)))
+	b += int((int(v.Length) * 4))
 
 	return v
 }
@@ -9516,7 +9514,7 @@ func getKeyboardControlReply(buf []byte) *GetKeyboardControlReply {
 
 	v.AutoRepeats = make([]byte, 32)
 	copy(v.AutoRepeats[:32], buf[b:])
-	b += xgb.Pad(int(32))
+	b += int(32)
 
 	return v
 }
@@ -9601,7 +9599,6 @@ func getKeyboardMappingReply(buf []byte) *GetKeyboardMappingReply {
 		v.Keysyms[i] = Keysym(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -9693,7 +9690,6 @@ func getModifierMappingReply(buf []byte) *GetModifierMappingReply {
 		v.Keycodes[i] = Keycode(buf[b])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -9957,7 +9953,7 @@ func getPointerMappingReply(buf []byte) *GetPointerMappingReply {
 
 	v.Map = make([]byte, v.MapLen)
 	copy(v.Map[:v.MapLen], buf[b:])
-	b += xgb.Pad(int(v.MapLen))
+	b += int(v.MapLen)
 
 	return v
 }
@@ -10051,7 +10047,7 @@ func getPropertyReply(buf []byte) *GetPropertyReply {
 
 	v.Value = make([]byte, (int(v.ValueLen) * (int(v.Format) / 8)))
 	copy(v.Value[:(int(v.ValueLen)*(int(v.Format)/8))], buf[b:])
-	b += xgb.Pad(int((int(v.ValueLen) * (int(v.Format) / 8))))
+	b += int((int(v.ValueLen) * (int(v.Format) / 8)))
 
 	return v
 }
@@ -10914,7 +10910,7 @@ func imageText8Request(c *xgb.Conn, StringLen byte, Drawable Drawable, Gc Gconte
 	b += 2
 
 	copy(buf[b:], String[:StringLen])
-	b += xgb.Pad(int(StringLen))
+	b += int(StringLen)
 
 	return buf
 }
@@ -11053,7 +11049,7 @@ func internAtomRequest(c *xgb.Conn, OnlyIfExists bool, NameLen uint16, Name stri
 	b += 2 // padding
 
 	copy(buf[b:], Name[:NameLen])
-	b += xgb.Pad(int(NameLen))
+	b += int(NameLen)
 
 	return buf
 }
@@ -11276,7 +11272,7 @@ func listFontsRequest(c *xgb.Conn, MaxNames uint16, PatternLen uint16, Pattern s
 	b += 2
 
 	copy(buf[b:], Pattern[:PatternLen])
-	b += xgb.Pad(int(PatternLen))
+	b += int(PatternLen)
 
 	return buf
 }
@@ -11434,7 +11430,7 @@ func listFontsWithInfoRequest(c *xgb.Conn, MaxNames uint16, PatternLen uint16, P
 	b += 2
 
 	copy(buf[b:], Pattern[:PatternLen])
-	b += xgb.Pad(int(PatternLen))
+	b += int(PatternLen)
 
 	return buf
 }
@@ -11590,7 +11586,6 @@ func listInstalledColormapsReply(buf []byte) *ListInstalledColormapsReply {
 		v.Cmaps[i] = Colormap(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -11682,7 +11677,6 @@ func listPropertiesReply(buf []byte) *ListPropertiesReply {
 		v.Atoms[i] = Atom(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -11812,7 +11806,7 @@ func lookupColorRequest(c *xgb.Conn, Cmap Colormap, NameLen uint16, Name string)
 	b += 2 // padding
 
 	copy(buf[b:], Name[:NameLen])
-	b += xgb.Pad(int(NameLen))
+	b += int(NameLen)
 
 	return buf
 }
@@ -12008,7 +12002,7 @@ func openFontRequest(c *xgb.Conn, Fid Font, NameLen uint16, Name string) []byte 
 	b += 2 // padding
 
 	copy(buf[b:], Name[:NameLen])
-	b += xgb.Pad(int(NameLen))
+	b += int(NameLen)
 
 	return buf
 }
@@ -12441,7 +12435,7 @@ func polyText16Request(c *xgb.Conn, Drawable Drawable, Gc Gcontext, X int16, Y i
 	b += 2
 
 	copy(buf[b:], Items[:len(Items)])
-	b += xgb.Pad(int(len(Items)))
+	b += int(len(Items))
 
 	return buf
 }
@@ -12501,7 +12495,7 @@ func polyText8Request(c *xgb.Conn, Drawable Drawable, Gc Gcontext, X int16, Y in
 	b += 2
 
 	copy(buf[b:], Items[:len(Items)])
-	b += xgb.Pad(int(len(Items)))
+	b += int(len(Items))
 
 	return buf
 }
@@ -12576,7 +12570,7 @@ func putImageRequest(c *xgb.Conn, Format byte, Drawable Drawable, Gc Gcontext, W
 	b += 2 // padding
 
 	copy(buf[b:], Data[:len(Data)])
-	b += xgb.Pad(int(len(Data)))
+	b += int(len(Data))
 
 	return buf
 }
@@ -12762,7 +12756,6 @@ func queryColorsRequest(c *xgb.Conn, Cmap Colormap, Pixels []uint32) []byte {
 		xgb.Put32(buf[b:], Pixels[i])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -12864,7 +12857,7 @@ func queryExtensionRequest(c *xgb.Conn, NameLen uint16, Name string) []byte {
 	b += 2 // padding
 
 	copy(buf[b:], Name[:NameLen])
-	b += xgb.Pad(int(NameLen))
+	b += int(NameLen)
 
 	return buf
 }
@@ -12911,7 +12904,8 @@ type QueryFontReply struct {
 	FontDescent    int16
 	CharInfosLen   uint32
 	Properties     []Fontprop // size: xgb.Pad((int(PropertiesLen) * 8))
-	CharInfos      []Charinfo // size: xgb.Pad((int(CharInfosLen) * 12))
+	// alignment gap to multiple of 4
+	CharInfos []Charinfo // size: xgb.Pad((int(CharInfosLen) * 12))
 }
 
 // Reply blocks and returns the reply data for a QueryFont request.
@@ -12988,6 +12982,8 @@ func queryFontReply(buf []byte) *QueryFontReply {
 
 	v.Properties = make([]Fontprop, v.PropertiesLen)
 	b += FontpropReadList(buf[b:], v.Properties)
+
+	b = (b + 3) & ^3 // alignment gap
 
 	v.CharInfos = make([]Charinfo, v.CharInfosLen)
 	b += CharinfoReadList(buf[b:], v.CharInfos)
@@ -13072,7 +13068,7 @@ func queryKeymapReply(buf []byte) *QueryKeymapReply {
 
 	v.Keys = make([]byte, 32)
 	copy(v.Keys[:32], buf[b:])
-	b += xgb.Pad(int(32))
+	b += int(32)
 
 	return v
 }
@@ -13392,7 +13388,6 @@ func queryTreeReply(buf []byte) *QueryTreeReply {
 		v.Children[i] = Window(xgb.Get32(buf[b:]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -13596,7 +13591,6 @@ func rotatePropertiesRequest(c *xgb.Conn, Window Window, AtomsLen uint16, Delta 
 		xgb.Put32(buf[b:], uint32(Atoms[i]))
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -13655,7 +13649,7 @@ func sendEventRequest(c *xgb.Conn, Propagate bool, Destination Window, EventMask
 	b += 4
 
 	copy(buf[b:], Event[:32])
-	b += xgb.Pad(int(32))
+	b += int(32)
 
 	return buf
 }
@@ -13861,7 +13855,7 @@ func setDashesRequest(c *xgb.Conn, Gc Gcontext, DashOffset uint16, DashesLen uin
 	b += 2
 
 	copy(buf[b:], Dashes[:DashesLen])
-	b += xgb.Pad(int(DashesLen))
+	b += int(DashesLen)
 
 	return buf
 }
@@ -14047,7 +14041,6 @@ func setModifierMappingRequest(c *xgb.Conn, KeycodesPerModifier byte, Keycodes [
 		buf[b] = byte(Keycodes[i])
 		b += 1
 	}
-	b = xgb.Pad(b)
 
 	return buf
 }
@@ -14126,7 +14119,7 @@ func setPointerMappingRequest(c *xgb.Conn, MapLen byte, Map []byte) []byte {
 	b += 2
 
 	copy(buf[b:], Map[:MapLen])
-	b += xgb.Pad(int(MapLen))
+	b += int(MapLen)
 
 	return buf
 }
@@ -14347,7 +14340,7 @@ func storeNamedColorRequest(c *xgb.Conn, Flags byte, Cmap Colormap, Pixel uint32
 	b += 2 // padding
 
 	copy(buf[b:], Name[:NameLen])
-	b += xgb.Pad(int(NameLen))
+	b += int(NameLen)
 
 	return buf
 }

--- a/xproto/xproto_test.go
+++ b/xproto/xproto_test.go
@@ -204,6 +204,23 @@ func TestWindowEvents(t *testing.T) {
 	}
 }
 
+// Calls GetFontPath function, Issue #12
+func TestGetFontPath(t *testing.T) {
+	fontPathReply, err := GetFontPath(X).Reply()
+	if err != nil {
+		t.Fatalf("GetFontPath: %v", err)
+	}
+	_ = fontPathReply
+}
+
+func TestListFonts(t *testing.T) {
+	listFontsReply, err := ListFonts(X, 10, 1, "*").Reply()
+	if err != nil {
+		t.Fatalf("ListFonts: %v", err)
+	}
+	_ = listFontsReply
+}
+
 /******************************************************************************/
 // Benchmarks
 /******************************************************************************/

--- a/xselinux/xselinux.go
+++ b/xselinux/xselinux.go
@@ -100,12 +100,12 @@ func (v ListItem) Bytes() []byte {
 	b += 4
 
 	copy(buf[b:], v.ObjectContext[:v.ObjectContextLen])
-	b += xgb.Pad(int(v.ObjectContextLen))
+	b += int(v.ObjectContextLen)
 
 	copy(buf[b:], v.DataContext[:v.DataContextLen])
-	b += xgb.Pad(int(v.DataContextLen))
+	b += int(v.DataContextLen)
 
-	return buf
+	return buf[:b]
 }
 
 // ListItemListBytes writes a list of ListItem values to a byte slice.
@@ -1766,7 +1766,7 @@ func setDeviceContextRequest(c *xgb.Conn, Device uint32, ContextLen uint32, Cont
 	b += 4
 
 	copy(buf[b:], Context[:ContextLen])
-	b += xgb.Pad(int(ContextLen))
+	b += int(ContextLen)
 
 	return buf
 }
@@ -1824,7 +1824,7 @@ func setDeviceCreateContextRequest(c *xgb.Conn, ContextLen uint32, Context strin
 	b += 4
 
 	copy(buf[b:], Context[:ContextLen])
-	b += xgb.Pad(int(ContextLen))
+	b += int(ContextLen)
 
 	return buf
 }
@@ -1882,7 +1882,7 @@ func setPropertyCreateContextRequest(c *xgb.Conn, ContextLen uint32, Context str
 	b += 4
 
 	copy(buf[b:], Context[:ContextLen])
-	b += xgb.Pad(int(ContextLen))
+	b += int(ContextLen)
 
 	return buf
 }
@@ -1940,7 +1940,7 @@ func setPropertyUseContextRequest(c *xgb.Conn, ContextLen uint32, Context string
 	b += 4
 
 	copy(buf[b:], Context[:ContextLen])
-	b += xgb.Pad(int(ContextLen))
+	b += int(ContextLen)
 
 	return buf
 }
@@ -1998,7 +1998,7 @@ func setSelectionCreateContextRequest(c *xgb.Conn, ContextLen uint32, Context st
 	b += 4
 
 	copy(buf[b:], Context[:ContextLen])
-	b += xgb.Pad(int(ContextLen))
+	b += int(ContextLen)
 
 	return buf
 }
@@ -2056,7 +2056,7 @@ func setSelectionUseContextRequest(c *xgb.Conn, ContextLen uint32, Context strin
 	b += 4
 
 	copy(buf[b:], Context[:ContextLen])
-	b += xgb.Pad(int(ContextLen))
+	b += int(ContextLen)
 
 	return buf
 }
@@ -2114,7 +2114,7 @@ func setWindowCreateContextRequest(c *xgb.Conn, ContextLen uint32, Context strin
 	b += 4
 
 	copy(buf[b:], Context[:ContextLen])
-	b += xgb.Pad(int(ContextLen))
+	b += int(ContextLen)
 
 	return buf
 }

--- a/xvmc/xvmc.go
+++ b/xvmc/xvmc.go
@@ -156,7 +156,7 @@ func (v SurfaceInfo) Bytes() []byte {
 	xgb.Put32(buf[b:], v.Flags)
 	b += 4
 
-	return buf
+	return buf[:b]
 }
 
 // SurfaceInfoListBytes writes a list of SurfaceInfo values to a byte slice.
@@ -275,7 +275,6 @@ func createContextReply(buf []byte) *CreateContextReply {
 		v.PrivData[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -397,7 +396,7 @@ func createSubpictureReply(buf []byte) *CreateSubpictureReply {
 
 	v.ComponentOrder = make([]byte, 4)
 	copy(v.ComponentOrder[:4], buf[b:])
-	b += xgb.Pad(int(4))
+	b += int(4)
 
 	b += 12 // padding
 
@@ -406,7 +405,6 @@ func createSubpictureReply(buf []byte) *CreateSubpictureReply {
 		v.PrivData[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }
@@ -513,7 +511,6 @@ func createSurfaceReply(buf []byte) *CreateSurfaceReply {
 		v.PrivData[i] = xgb.Get32(buf[b:])
 		b += 4
 	}
-	b = xgb.Pad(b)
 
 	return v
 }


### PR DESCRIPTION
Changed xgbgen so that it puts alignment padding between lists so that the first element of every list is aligned to 4 bytes (if the size of the list element is more than 4 bytes) or to the size of the list's element struct.
This doesn't make any sense to me but it seems to be what xcb c_client.py does. Tests and examples work on my machine.
Requests are padded to 4 bytes, always.
I also added a test case for Issue #12.
