### PR TITLE
fix race condition in xgb.go

### DIFF
--- a/xgb.go
+++ b/xgb.go
@@ -270,6 +270,9 @@ func (c *Conn) generateSeqIds() {
 type request struct {
 	buf    []byte
 	cookie *Cookie
+
+	// seq is closed when the request (cookie) has been sequenced by the Conn.
+	seq chan struct{}
 }
 
 // NewRequest takes the bytes and a cookie of a particular request, constructs
@@ -291,7 +294,9 @@ type request struct {
 // In all likelihood, you should be able to copy and paste with some minor
 // edits the generated code for the request you want to issue.
 func (c *Conn) NewRequest(buf []byte, cookie *Cookie) {
-	c.reqChan <- &request{buf: buf, cookie: cookie}
+	seq := make(chan struct{})
+	c.reqChan <- &request{buf: buf, cookie: cookie, seq: seq}
+	<-seq
 }
 
 // sendRequests is run as a single goroutine that takes requests and writes
@@ -309,6 +314,7 @@ func (c *Conn) sendRequests() {
 			c.noop()
 		}
 		req.cookie.Sequence = c.newSequenceId()
+		close(req.seq)
 		c.cookieChan <- req.cookie
 		c.writeBuffer(req.buf)
 	}


### PR DESCRIPTION
The xgb package has a data race exercised by the xproto tests and several example programs. The cookie sequence id is set concurrently with it being checked in an xproto Check call.

To resolve the race I've made the Conn.NewRequest method block until the request has been assigned a sequence id. I did that by adding a channel to the struct that is closed after a sequence id is assigned. It's a little bit of a hack but it seemed like the cleanest thing to do, due to the type being unexpected.

What do you think @BurntSushi?