### PR TITLE
add a new api: NewConnNet. So we can init a xgb.Conn from a net.Conn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -29,6 +29,17 @@ func (c *Conn) connect(display string) error {
 		return err
 	}
 
+	return c.postConnect()
+}
+
+// connect init from to the net.Conn,
+func (c *Conn) connectNet(netConn net.Conn) error {
+	c.conn = netConn
+	return c.postConnect()
+}
+
+// do the postConnect action after Conn get it's underly net.Conn
+func (c *Conn) postConnect() error {
 	// Get authentication data
 	authName, authData, err := readAuthority(c.host, c.display)
 	noauth := false

--- a/xgb.go
+++ b/xgb.go
@@ -98,6 +98,26 @@ func NewConnDisplay(display string) (*Conn, error) {
 		return nil, err
 	}
 
+	return postNewConn(conn)
+}
+
+// NewConnDisplay is just like NewConn, but allows a specific net.Conn
+// to be used.
+func NewConnNet(netConn net.Conn) (*Conn, error) {
+	conn := &Conn{}
+
+	// First connect. This reads authority, checks DISPLAY environment
+	// variable, and loads the initial Setup info.
+	err := conn.connectNet(netConn)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return postNewConn(conn)
+}
+
+func postNewConn(conn *Conn) (*Conn, error) {
 	conn.Extensions = make(map[string]byte)
 
 	conn.cookieChan = make(chan *Cookie, cookieBuffer)


### PR DESCRIPTION
This PR add a new api:  func NewConnNet(netConn net.Conn) (*Conn, error). We can use it to get a `xgb.Conn` from a existing `net.Conn`.

example:
```
	file := os.NewFile(fd, "example")
	netConn, _ := net.FileConn(file)
	xgbConn, _ := xgb.NewConnNet(netConn)

```