### PR TITLE
sendRequest reads req.buf after closing req.seq

### DIFF
--- a/xgb.go
+++ b/xgb.go
@@ -337,9 +337,9 @@ func (c *Conn) sendRequests() {
 			}
 		}
 		req.cookie.Sequence = c.newSequenceId()
-		close(req.seq)
 		c.cookieChan <- req.cookie
 		c.writeBuffer(req.buf)
+		close(req.seq)
 	}
 	response := make(chan struct{})
 	c.closing <- response


### PR DESCRIPTION
NewRequest says you can avoid reallocating a new buffer for each request by calling it directly.
This is not true if req.seq is closed before req.buf is read.