### PR TITLE
Handle wildcard values in Xauthority file

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -25,6 +25,7 @@ func readAuthority(hostname, display string) (
 
 	// As per /usr/include/X11/Xauth.h.
 	const familyLocal = 256
+	const familyWild = 65535
 
 	if len(hostname) == 0 || hostname == "localhost" {
 		hostname, err = os.Hostname()
@@ -75,7 +76,10 @@ func readAuthority(hostname, display string) (
 			return "", nil, err
 		}
 
-		if family == familyLocal && addr == hostname && disp == display {
+		addrmatch := (family == familyWild) || (family == familyLocal && addr == hostname)
+		dispmatch := (disp == "") || (disp == display)
+
+		if addrmatch && dispmatch {
 			return name0, data0, nil
 		}
 	}


### PR DESCRIPTION
Some field values in the Xauthority file have special meanings:
- a value of 65535 in the 'family' field means that the entry will
match a connection of any family on any address
- an empty string in the 'display number' field means that the entry
will match a connection on any display number

This behaviour is documented at:
https://cgit.freedesktop.org/xorg/lib/libXau/tree/AuGetBest.c#n109