### PR TITLE
Removed ineffectual assignment

### DIFF
--- a/xgbgen/request_reply.go
+++ b/xgbgen/request_reply.go
@@ -27,9 +27,6 @@ func (rs Requests) Less(i, j int) bool { return rs[i].xmlName < rs[j].xmlName }
 // It also initializes the reply if one exists, and all fields in this request.
 func (r *Request) Initialize(p *Protocol) {
 	r.srcName = SrcName(p, r.xmlName)
-	if p.isExt() {
-		r.srcName = r.srcName
-	}
 
 	if r.Reply != nil {
 		r.Reply.Initialize(p)


### PR DESCRIPTION
Assigning r.srcName to itself seems to have no effect here (unlike in benchmarks).
Please review thoroughly as I've also removed the call to p.isExt(), which
hopefully doesn't have any side-effects.