### PR TITLE
Fix unix:0.0 DISPLAY connections

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -168,13 +168,14 @@ func (c *Conn) dial(display string) error {
 	// Connect to server
 	if len(socket) != 0 {
 		c.conn, err = net.Dial("unix", socket+":"+c.display)
-	} else if len(c.host) != 0 {
+	} else if len(c.host) != 0 && c.host != "unix" {
 		if protocol == "" {
 			protocol = "tcp"
 		}
 		c.conn, err = net.Dial(protocol,
 			c.host+":"+strconv.Itoa(6000+c.DisplayNumber))
 	} else {
+		c.host = ""
 		c.conn, err = net.Dial("unix", "/tmp/.X11-unix/X"+c.display)
 	}
 


### PR DESCRIPTION
According to the spec at https://www.x.org/archive/X11R6.8.0/doc/Xorg.1.html#sect5 the DISPLAY string unix:0.0 is special.
This forces connections to use the unix socket at this address even if they would normally lookup TCP first.
Simple fix so that we fall through to the unix socket in this case.