### PR TITLE
Mz fixes

### DIFF
--- a/xgb.go
+++ b/xgb.go
@@ -239,6 +239,7 @@ func (conn *Conn) generateXIds() {
 	inc := conn.setupResourceIdMask & -conn.setupResourceIdMask
 	max := conn.setupResourceIdMask
 	last := uint32(0)
+	// TODO loop should be stopped when conn is closed (possible memory leak)
 	for {
 		// TODO: Use the XC Misc extension to look for released ids.
 		if last > 0 && last >= max-inc+1 {
@@ -274,6 +275,7 @@ func (c *Conn) generateSeqIds() {
 	defer close(c.seqChan)
 
 	seqid := uint16(1)
+	// TODO loop should be stopped when conn is closed (possible memory leak)
 	for {
 		c.seqChan <- seqid
 		if seqid == uint16((1<<16)-1) {


### PR DESCRIPTION
I prepared some small changes which prevent some edge cases of XGB usage.

I can reproduce the panic errors on Xvfb connections when Xvfb is killed externally.
These changes will keep Go app alive just with a closed X server connection.
There are still some questions on running go routines in BG (see new TODO comments).

I'm free to discuss changes and update PR.