### PR TITLE
Create go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/BurntSushi/xgb


### PR DESCRIPTION
Without a `go.mod`, the build fails with error:

```
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
```

Note that since go 1.16, the `go` command will build packages in module-aware mode by default, see: https://go.dev/blog/go116-module-changes#modules-on-by-default